### PR TITLE
Normalize release PR body to UTF-8 and cover ASCII-8BIT case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # git-pr-release
 
+## v2.2.0.2 (2025-11-21)
+
+[full changelog](https://github.com/shimx/git-pr-release/compare/v2.2.0.1...v2.2.0.2)
+
 ## v2.2.0.1 (2023-06-20)
 
 [full changelog](https://github.com/shimx/git-pr-release/compare/v2.2.0...v2.2.0.1)
@@ -10,110 +14,110 @@
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v2.1.2...v2.2.0)
 
-* (#88) unshallow if a shallow repository (@Songmu)
-* (#89) Add overwrite-description option (@onk)
+- (#88) unshallow if a shallow repository (@Songmu)
+- (#89) Add overwrite-description option (@onk)
 
 ## v2.1.2 (2022-07-29)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v2.1.1...v2.1.2)
 
-* (#87) delegate to `@pr` when `method_missing` in PullRequest (@Songmu)
+- (#87) delegate to `@pr` when `method_missing` in PullRequest (@Songmu)
 
 ## v2.1.1 (2022-03-09)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v2.1.0...v2.1.1)
 
-* (#81) fix forbidden git config name (#80) (@mtgto)
+- (#81) fix forbidden git config name (#80) (@mtgto)
 
 ## v2.1.0 (2022-03-03)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v2.0.0...v2.1.0)
 
-* (#75) reduce GitHub search API calls when the squashed option is specified (@Songmu)
-* (#76) use bulk issue search to reduce API calls (@Songmu)
-* (#77) Add option "ssl_no_verify" to skip verifying ssl certificate (@mtgto)
-* (#78) add an argument to to_checklist_item to print pr title (@mtgto)
+- (#75) reduce GitHub search API calls when the squashed option is specified (@Songmu)
+- (#76) use bulk issue search to reduce API calls (@Songmu)
+- (#77) Add option "ssl_no_verify" to skip verifying ssl certificate (@mtgto)
+- (#78) add an argument to to_checklist_item to print pr title (@mtgto)
 
 ## v2.0.0 (2022-02-17)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v1.9.0...v2.0.0)
 
-* (#69) remove duplicated PR entries at squash (@Yuki-Inoue)
-* (#70) [Spec] Fix spec for build_pr_title_and_body (@yutailang0119)
-* (#71) Introduce CI (@ohbarye)
-* (#73) (#74) Use `YAML.unsafe_load_file` instead of `YAML.load_file` (@ohbarye)
+- (#69) remove duplicated PR entries at squash (@Yuki-Inoue)
+- (#70) [Spec] Fix spec for build_pr_title_and_body (@yutailang0119)
+- (#71) Introduce CI (@ohbarye)
+- (#73) (#74) Use `YAML.unsafe_load_file` instead of `YAML.load_file` (@ohbarye)
 
 ## v1.9.0 (2021-08-04)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v1.8.0...v1.9.0)
 
-* (#68) Add nil check for release\_pr.body (@w1mvy)
+- (#68) Add nil check for release_pr.body (@w1mvy)
 
 ## v1.8.0 (2021-06-24)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v1.7.0...v1.8.0)
 
-* (#66) Exclude titles from checklist items (@nhosoya)
+- (#66) Exclude titles from checklist items (@nhosoya)
 
 ## v1.7.0 (2021-05-24)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v1.6.0...v1.7.0)
 
-* (#64) fix wrong pr number due to sleep (@mpon)
+- (#64) fix wrong pr number due to sleep (@mpon)
 
 ## v1.6.0 (2021-05-15)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v1.5.0...v1.6.0)
 
-* (#63) Sort merged_pull_request_numbers numerically by default (@yutailang0119)
+- (#63) Sort merged_pull_request_numbers numerically by default (@yutailang0119)
 
 ## v1.5.0 (2021-04-02)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v1.4.0...v1.5.0)
 
-* (#60, #61) Get issue number from GitHub API for squashed PR (@yuuan)
-* (#58) Make stable test (@kachick)
-* (#55) Suppress warning for ERB (@ohbarye)
-* (#50) support `GIT_PR_RELEASE_MENTION` environment variable (@dabutvin)
-* (#49) Transfer repository to x-motemen organization (@onk)
+- (#60, #61) Get issue number from GitHub API for squashed PR (@yuuan)
+- (#58) Make stable test (@kachick)
+- (#55) Suppress warning for ERB (@ohbarye)
+- (#50) support `GIT_PR_RELEASE_MENTION` environment variable (@dabutvin)
+- (#49) Transfer repository to x-motemen organization (@onk)
 
 ## v1.4.0 (2020-02-22)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v1.3.0...v1.4.0)
 
-* (#48) List PR API needs head user or head organization and branch name (@sasasin)
+- (#48) List PR API needs head user or head organization and branch name (@sasasin)
 
 ## v1.3.0 (2020-02-19)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v1.2.0...v1.3.0)
 
-* (#47) Fix Errno::ENOENT when finding the specified template (@onk)
-* (#45) Fix "warning: instance variable @xxx not initialized" (@onk)
+- (#47) Fix Errno::ENOENT when finding the specified template (@onk)
+- (#45) Fix "warning: instance variable @xxx not initialized" (@onk)
 
 ## v1.2.0 (2020-02-07)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v1.1.0...v1.2.0)
 
-* (#44) Use API option when detecting existing release PR (@onk)
-* (#41, #42) Refactor (@onk)
+- (#44) Use API option when detecting existing release PR (@onk)
+- (#41, #42) Refactor (@onk)
   - Some local variables are removed. This will break if you have customized the template ERB.
 
 ## v1.1.0 (2020-01-02)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v1.0.1...v1.1.0)
 
-* (#38) Fetch changed files as many as possible (@shibayu36)
+- (#38) Fetch changed files as many as possible (@shibayu36)
 
 ## v1.0.1 (2019-12-17)
 
 [full changelog](https://github.com/x-motemen/git-pr-release/compare/v1.0.0...v1.0.1)
 
-* (#37) Fix NameError (@onk)
+- (#37) Fix NameError (@onk)
 
 ## v1.0.0 (2019-12-14)
 
-* (#35) Do not define classes and methods at the top level (@onk)
-* (#30) Extract logic from bin/git-pr-release (@banyan)
+- (#35) Do not define classes and methods at the top level (@onk)
+- (#30) Extract logic from bin/git-pr-release (@banyan)
 
 ...
 

--- a/git-pr-release.gemspec
+++ b/git-pr-release.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "git-pr-release"
-  spec.version       = '2.2.0.1'
+  spec.version       = '2.2.0.2'
   spec.authors       = ["shimx"]
   spec.email         = ["info@shimx.net"]
   spec.summary       = 'Creates a release pull request'

--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -113,18 +113,20 @@ ERB
 
         def merge_pr_body(old_body, new_body)
           # Try to take over checklist statuses
+          force_encoded_old_body = old_body.force_encoding('UTF-8')
+          force_encoded_new_body = new_body.force_encoding('UTF-8')
           pr_body_lines = []
 
           check_status = {}
-          old_body.split(/\r?\n/).each { |line|
+          force_encoded_old_body.split(/\r?\n/).each { |line|
             line.match(/^- \[(?<check_value>[ x])\] #(?<issue_number>\d+)/) { |m|
               say "Found pull-request checkbox \##{m[:issue_number]} is #{m[:check_value]}.", :trace
               check_status[m[:issue_number]] = m[:check_value]
             }
           }
-          old_body_unchecked = old_body.gsub /^- \[[ x]\] \#(\d+)/, '- [ ] #\1'
+          old_body_unchecked = force_encoded_old_body.gsub /^- \[[ x]\] \#(\d+)/, '- [ ] #\1'
 
-          Diff::LCS.traverse_balanced(old_body_unchecked.split(/\r?\n/), new_body.split(/\r?\n/)) do |event|
+          Diff::LCS.traverse_balanced(old_body_unchecked.split(/\r?\n/), force_encoded_new_body.split(/\r?\n/)) do |event|
             say "diff: #{event.inspect}", :trace
             action, old, new = *event
             old_nr, old_line = *old
@@ -154,7 +156,7 @@ ERB
             end
           end
 
-          merged_body = pr_body_lines.map { _1.force_encoding('UTF-8') }.join("\n")
+          merged_body = pr_body_lines.join("\n")
           check_status.each { |issue_number, check_value|
             say "Update pull-request checkbox \##{issue_number} to #{check_value}.", :trace
             merged_body.gsub! /^- \[ \] \##{issue_number}\b/, "- [#{check_value}] \##{issue_number}"

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -411,19 +411,19 @@ RSpec.describe Git::Pr::Release::CLI do
       @cli = configured_cli
 
       @merged_prs = [double(Sawyer::Resource)]
-      allow(@cli).to receive(:build_pr_title_and_body) { ["PR Title", "PR Body"] }
+      allow(@cli).to receive(:build_pr_title_and_body) { ["PR Title", "PR Body".force_encoding(Encoding::ASCII_8BIT)] }
       allow(@cli).to receive(:merge_pr_body) { "Merged Body" }
     }
 
     context "When release_pr exists" do
-      let(:release_pr) { double(body: "Old Body") }
+      let(:release_pr) { double(body: "【Old Body】") }
       let(:changed_files) { [double(Sawyer::Resource)] }
 
       it {
         is_expected.to eq ["PR Title", "Merged Body"]
 
         expect(@cli).to have_received(:build_pr_title_and_body).with(release_pr, @merged_prs, changed_files, nil)
-        expect(@cli).to have_received(:merge_pr_body).with("Old Body", "PR Body")
+        expect(@cli).to have_received(:merge_pr_body).with("【Old Body】", "PR Body")
       }
     end
 


### PR DESCRIPTION
## Summary
- Add a regression test that reproduces Encoding::CompatibilityError when the release PR body contains ASCII-8BIT string
- Normalize release PR bodies to UTF-8 before merging to resolve the error

## Testing
- bundle exec rspec spec/git/pr/release/cli_spec.rb