### PR TITLE
Add recursive option

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -14,10 +14,11 @@ module Git
         end
 
         def initialize
-          @dry_run  = false
-          @json     = false
-          @no_fetch = false
-          @squashed = false
+          @dry_run   = false
+          @json      = false
+          @no_fetch  = false
+          @squashed  = false
+          @recursive = false
         end
 
         def start
@@ -34,6 +35,9 @@ module Git
             opts.on('--squashed', 'Handle squash merged PRs') do |v|
               @squashed = v
             end
+            opts.on('--recursive', 'Include PRs merged into feature branches (use with --squashed)') do |v|
+              @recursive = v
+            end
             opts.on('--overwrite-description', 'Force overwrite PR description') do |v|
               @overwrite_description = v
             end
@@ -41,6 +45,11 @@ module Git
 
           ### Set up configuration
           configure
+
+          if @recursive && !@squashed
+            say '--recursive requires --squashed, ignoring --recursive', :warn
+            @recursive = false
+          end
 
           ### Fetch merged PRs
           merged_prs = fetch_merged_prs
@@ -87,6 +96,11 @@ module Git
 
           _request_pr_author_review = ENV.fetch('GIT_PR_RELEASE_REQUEST_PR_AUTHOR_REVIEW') { git_config('request-pr-author-review') }
           @request_pr_author_review = %w[true 1].include?(_request_pr_author_review)
+
+          unless @recursive
+            _recursive = ENV.fetch('GIT_PR_RELEASE_RECURSIVE') { git_config('recursive') }
+            @recursive = %w[true 1].include?(_recursive)
+          end
 
           say "Repository:        #{repository}", :debug
           say "Production branch: #{production_branch}", :debug
@@ -163,8 +177,10 @@ module Git
           # ref. https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-commit-sha
           # This is done because there is a length limit on the API query string, and we want
           # to create a string with the minimum possible length.
-          shas = git(:log, '--pretty=format:%h', "--abbrev=7", "--no-merges", "--first-parent",
-            "origin/#{production_branch}..origin/#{staging_branch}").map(&:chomp)
+          git_log_options = %w[--pretty=format:%h --abbrev=7 --no-merges]
+          git_log_options << '--first-parent' unless @recursive
+          git_log_options << "origin/#{production_branch}..origin/#{staging_branch}"
+          shas = git(:log, *git_log_options).map(&:chomp)
 
           pr_nums = []
           query_base = "repo:#{repository} is:pr is:closed"

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -30,6 +30,29 @@ RSpec.describe Git::Pr::Release::CLI do
       }
     end
 
+    context "When --recursive without --squashed" do
+      let(:merged_prs) {
+        agent = Sawyer::Agent.new("http://example.com/") do |conn|
+          conn.builder.handlers.delete(Faraday::Adapter::NetHttp)
+          conn.adapter(:test, Faraday::Adapter::Test::Stubs.new)
+        end
+        pr_3 = Sawyer::Resource.new(agent, load_yaml("pr_3.yml"))
+        [pr_3]
+      }
+
+      before {
+        @cli.instance_variable_set(:@recursive, true)
+        @cli.instance_variable_set(:@squashed, false)
+        allow(@cli).to receive(:say).and_call_original
+      }
+
+      it "warns and ignores --recursive" do
+        subject
+        expect(@cli).to have_received(:say).with('--recursive requires --squashed, ignoring --recursive', :warn)
+        expect(@cli.instance_variable_get(:@recursive)).to eq false
+      end
+    end
+
     context "When merged_prs exists" do
       let(:merged_prs) {
         agent = Sawyer::Agent.new("http://example.com/") do |conn|
@@ -308,6 +331,81 @@ RSpec.describe Git::Pr::Release::CLI do
         it "enables request_pr_author_review" do
           subject
           expect(@cli.request_pr_author_review).to eq true
+        end
+      end
+    end
+
+    describe "recursive" do
+      context "With ENV set to true" do
+        around do |example|
+          original = ENV.to_hash
+          begin
+            ENV["GIT_PR_RELEASE_RECURSIVE"] = "true"
+            example.run
+          ensure
+            ENV.replace(original)
+          end
+        end
+
+        it "enables recursive" do
+          subject
+          expect(@cli.instance_variable_get(:@recursive)).to eq true
+        end
+      end
+
+      context "With ENV set to 1" do
+        around do |example|
+          original = ENV.to_hash
+          begin
+            ENV["GIT_PR_RELEASE_RECURSIVE"] = "1"
+            example.run
+          ensure
+            ENV.replace(original)
+          end
+        end
+
+        it "enables recursive" do
+          subject
+          expect(@cli.instance_variable_get(:@recursive)).to eq true
+        end
+      end
+
+      context "With ENV set to false" do
+        around do |example|
+          original = ENV.to_hash
+          begin
+            ENV["GIT_PR_RELEASE_RECURSIVE"] = "false"
+            example.run
+          ensure
+            ENV.replace(original)
+          end
+        end
+
+        it "disables recursive" do
+          subject
+          expect(@cli.instance_variable_get(:@recursive)).to eq false
+        end
+      end
+
+      context "With git_config" do
+        before {
+          allow(@cli).to receive(:git_config).with("recursive") { "true" }
+        }
+
+        it "enables recursive" do
+          subject
+          expect(@cli.instance_variable_get(:@recursive)).to eq true
+        end
+      end
+
+      context "When already set via CLI flag" do
+        before {
+          @cli.instance_variable_set(:@recursive, true)
+        }
+
+        it "does not override CLI flag with ENV/git_config" do
+          subject
+          expect(@cli.instance_variable_get(:@recursive)).to eq true
         end
       end
     end
@@ -769,5 +867,22 @@ RSpec.describe Git::Pr::Release::CLI do
         expect(@cli).to have_received(:search_issue_numbers).once
       end
     end
+
+    context "When @recursive is true" do
+      before {
+        @cli.instance_variable_set(:@recursive, true)
+        allow(@cli).to receive(:git).with(:log, '--pretty=format:%h', "--abbrev=7", "--no-merges",
+          "origin/master..origin/staging") { shas.map { |sha| "#{sha}\n" } }
+      }
+
+      let(:shas) { ["abc1234", "def5678"] }
+
+      it "does not use --first-parent" do
+        subject
+        expect(@cli).to have_received(:git).with(:log, '--pretty=format:%h', "--abbrev=7", "--no-merges",
+          "origin/master..origin/staging")
+      end
+    end
   end
+
 end


### PR DESCRIPTION
Closes #119

Add a `--recursive` option that, when used with `--squashed`, removes the `--first-parent` flag from `git log`, allowing squash merge commits within feature branches to also be detected. See #119 for the detailed motivation and workflow example.

## Changes

- **CLI option**: `--recursive` flag, `GIT_PR_RELEASE_RECURSIVE` env var, `pr-release.recursive` git config
- **Behavior**: When enabled, `fetch_squash_merged_pr_numbers_from_github` omits `--first-parent` from `git log`, so commits from merged feature branches are included in the SHA search
- **Guard**: `--recursive` without `--squashed` emits a warning and is ignored
- **No additional API cost**: Only the scope of SHAs changes — no new API calls